### PR TITLE
feat: Add Live Ask mode with voice questions and session continuity

### DIFF
--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -106,6 +106,7 @@ class MeetingProcessRequest(BaseModel):
 class JiraQuestionRequest(BaseModel):
     question: str
     project_key: str
+    session_id: Optional[str] = None  # For continuing conversations
 
 
 # Work schemas

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -1,0 +1,141 @@
+"""
+Session Manager for Claude Agent SDK
+
+Maintains Claude SDK client sessions to support multi-turn conversations.
+"""
+
+import asyncio
+from typing import Dict, Optional, Any, Callable, Coroutine
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+import uuid
+
+from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
+
+
+@dataclass
+class Session:
+    """A Claude SDK session with conversation context."""
+    session_id: str
+    user_id: int
+    client: ClaudeSDKClient
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    last_activity: datetime = field(default_factory=datetime.utcnow)
+    is_processing: bool = False
+
+
+class SessionManager:
+    """Manages Claude SDK sessions for multi-turn conversations."""
+
+    def __init__(self, session_timeout_minutes: int = 30):
+        self._sessions: Dict[str, Session] = {}
+        self._user_sessions: Dict[int, str] = {}  # user_id -> session_id
+        self._session_timeout = timedelta(minutes=session_timeout_minutes)
+        self._cleanup_task: Optional[asyncio.Task] = None
+
+    async def start(self):
+        """Start the background cleanup task."""
+        if self._cleanup_task is None:
+            self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+
+    async def stop(self):
+        """Stop the cleanup task and close all sessions."""
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+
+        # Close all active sessions
+        for session_id in list(self._sessions.keys()):
+            await self.close_session(session_id)
+
+    async def _cleanup_loop(self):
+        """Periodically clean up expired sessions."""
+        while True:
+            await asyncio.sleep(60)  # Check every minute
+            await self._cleanup_expired()
+
+    async def _cleanup_expired(self):
+        """Remove sessions that have been inactive for too long."""
+        now = datetime.utcnow()
+        expired = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if now - session.last_activity > self._session_timeout
+            and not session.is_processing
+        ]
+        for session_id in expired:
+            print(f"[SessionManager] Cleaning up expired session: {session_id}")
+            await self.close_session(session_id)
+
+    def get_session(self, session_id: str) -> Optional[Session]:
+        """Get a session by ID."""
+        session = self._sessions.get(session_id)
+        if session:
+            session.last_activity = datetime.utcnow()
+        return session
+
+    def get_user_session(self, user_id: int) -> Optional[Session]:
+        """Get the active session for a user."""
+        session_id = self._user_sessions.get(user_id)
+        if session_id:
+            return self.get_session(session_id)
+        return None
+
+    async def create_session(
+        self,
+        user_id: int,
+        options: ClaudeAgentOptions
+    ) -> Session:
+        """Create a new session for a user, closing any existing session."""
+        # Close existing session for this user
+        existing_session_id = self._user_sessions.get(user_id)
+        if existing_session_id:
+            await self.close_session(existing_session_id)
+
+        # Create new session
+        session_id = str(uuid.uuid4())
+        client = ClaudeSDKClient(options=options)
+
+        # Enter the async context manager
+        await client.__aenter__()
+
+        session = Session(
+            session_id=session_id,
+            user_id=user_id,
+            client=client
+        )
+
+        self._sessions[session_id] = session
+        self._user_sessions[user_id] = session_id
+
+        print(f"[SessionManager] Created session {session_id} for user {user_id}")
+        return session
+
+    async def close_session(self, session_id: str):
+        """Close and remove a session."""
+        session = self._sessions.pop(session_id, None)
+        if session:
+            # Remove user mapping
+            if self._user_sessions.get(session.user_id) == session_id:
+                del self._user_sessions[session.user_id]
+
+            # Close the client
+            try:
+                await session.client.__aexit__(None, None, None)
+            except Exception as e:
+                print(f"[SessionManager] Error closing session {session_id}: {e}")
+
+            print(f"[SessionManager] Closed session {session_id}")
+
+    async def close_user_session(self, user_id: int):
+        """Close the session for a specific user."""
+        session_id = self._user_sessions.get(user_id)
+        if session_id:
+            await self.close_session(session_id)
+
+
+# Global session manager instance
+session_manager = SessionManager()

--- a/frontend/static/css/styles.css
+++ b/frontend/static/css/styles.css
@@ -2473,3 +2473,338 @@ a.action-card:hover .action-key {
     opacity: 0.5;
     cursor: not-allowed;
 }
+
+/* =====================================================
+   Live Ask Mode
+   ===================================================== */
+
+/* Live Ask Button in Ask Mode */
+.live-ask-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--surface-3);
+    color: var(--text-1);
+    border: 1px solid var(--border);
+}
+
+.live-ask-btn:hover {
+    background: var(--surface-4);
+}
+
+.live-ask-btn.recording {
+    background: var(--error);
+    color: white;
+    border-color: var(--error);
+    animation: pulse-glow 1s ease-in-out infinite;
+}
+
+.live-ask-btn.transcribing,
+.live-ask-btn.processing {
+    background: var(--primary);
+    color: white;
+    border-color: var(--primary);
+}
+
+.live-ask-btn.loading {
+    background: var(--surface-4);
+    color: var(--text-2);
+}
+
+.live-ask-btn svg {
+    flex-shrink: 0;
+}
+
+/* Follow-up Input for Ask Mode */
+.follow-up-input {
+    padding: 1rem;
+    border-top: 1px solid var(--border);
+    background: var(--surface-1);
+}
+
+.follow-up-container {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.follow-up-field {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface-2);
+    color: var(--text-1);
+    font-size: 1rem;
+}
+
+.follow-up-field:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+}
+
+.follow-up-field::placeholder {
+    color: var(--text-3);
+}
+
+.follow-up-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.follow-up-actions .btn {
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    height: auto;
+    min-height: unset;
+}
+
+.follow-up-actions .live-ask-btn {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+}
+
+.follow-up-actions .btn-primary {
+    padding: 0.5rem 0.75rem;
+}
+
+.follow-up-actions .btn-primary svg {
+    width: 18px;
+    height: 18px;
+}
+
+/* Conversation View Styles */
+.output-content.conversation-view {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.conversation-message {
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    max-width: 100%;
+}
+
+.conversation-message.user {
+    background: var(--surface-3);
+    border-left: 3px solid var(--accent);
+}
+
+.conversation-message.assistant {
+    background: var(--surface-2);
+    border-left: 3px solid var(--primary);
+}
+
+.message-role {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+    color: var(--text-3);
+}
+
+.conversation-message.user .message-role {
+    color: var(--accent);
+}
+
+.conversation-message.assistant .message-role {
+    color: var(--primary);
+}
+
+.message-content {
+    color: var(--text-1);
+    line-height: 1.6;
+}
+
+.conversation-message.user .message-content {
+    white-space: pre-wrap;
+}
+
+/* More spacing for input actions in Ask mode */
+.input-actions-centered {
+    gap: 1rem;
+}
+
+/* Old toggle styles - keeping for reference */
+.live-ask-toggle {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: var(--surface-3);
+    color: var(--text-2);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    margin-right: 1rem;
+}
+
+.live-ask-toggle:hover {
+    background: var(--surface-4);
+    color: var(--text-1);
+}
+
+.live-ask-toggle.active {
+    background: var(--primary);
+    color: white;
+}
+
+.live-ask-toggle.loading {
+    background: var(--surface-4);
+    color: var(--warning);
+}
+
+.live-ask-toggle.recording {
+    background: var(--error);
+    color: white;
+    animation: pulse-glow 1s ease-in-out infinite;
+}
+
+.live-ask-toggle.listening {
+    background: var(--primary);
+    color: white;
+    animation: pulse-glow 2s ease-in-out infinite;
+}
+
+.live-ask-toggle.transcribing {
+    background: var(--info);
+    color: white;
+}
+
+.live-ask-toggle.processing {
+    background: var(--success);
+    color: white;
+}
+
+.live-ask-toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Pulse dot for listening state */
+.live-ask-toggle .pulse-dot {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    background: var(--error);
+    border-radius: 50%;
+    animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+    0%, 100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    50% {
+        transform: scale(1.3);
+        opacity: 0.7;
+    }
+}
+
+@keyframes pulse-glow {
+    0%, 100% {
+        box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.4);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(99, 102, 241, 0);
+    }
+}
+
+/* Progress ring for model loading */
+.live-ask-toggle .progress-ring {
+    position: absolute;
+    bottom: -4px;
+    right: -4px;
+    font-size: 0.6rem;
+    background: var(--surface-1);
+    color: var(--text-1);
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+/* Live Ask Transcription Display */
+.live-ask-transcription {
+    position: fixed;
+    top: 120px;
+    right: 2rem;
+    width: 300px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    max-height: calc(100vh - 100px);
+    overflow-y: auto;
+}
+
+.live-ask-transcription-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-2);
+    margin-bottom: 0.5rem;
+}
+
+.live-ask-status-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--text-3);
+}
+
+.live-ask-status-indicator.listening {
+    background: var(--success);
+    animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+.live-ask-status-indicator.recording {
+    background: var(--error);
+    animation: pulse-dot 0.5s ease-in-out infinite;
+}
+
+.live-ask-status-indicator.transcribing {
+    background: var(--info);
+    animation: pulse-dot 1s ease-in-out infinite;
+}
+
+.live-ask-status-indicator.processing {
+    background: var(--warning);
+    animation: pulse-dot 0.8s ease-in-out infinite;
+}
+
+.live-ask-transcription-text {
+    font-size: 1rem;
+    color: var(--text-1);
+    font-style: italic;
+    line-height: 1.5;
+}
+
+.live-ask-transcription-text.muted {
+    color: var(--text-3);
+    font-style: normal;
+}
+
+.live-ask-transcription-text.error {
+    color: var(--error);
+    font-style: normal;
+}
+
+.live-ask-status-indicator.loading {
+    background: var(--warning);
+    animation: pulse-dot 1s ease-in-out infinite;
+}

--- a/frontend/static/js/live-ask/audio-capture.js
+++ b/frontend/static/js/live-ask/audio-capture.js
@@ -1,0 +1,199 @@
+/**
+ * AudioCaptureManager - Handles microphone capture (Push-to-Talk)
+ *
+ * Simple approach: hold button to record, release to transcribe.
+ */
+
+export class AudioCaptureManager {
+    constructor(options = {}) {
+        // Configuration
+        this.sampleRate = options.sampleRate || 16000; // Whisper needs 16kHz
+
+        // State
+        this.isRecording = false;
+        this.stream = null;
+        this.audioContext = null;
+        this.processor = null;
+        this.source = null;
+        this.audioBuffer = [];
+
+        // Callbacks
+        this.onAudioCaptured = options.onAudioCaptured || (() => {});
+        this.onError = options.onError || console.error;
+        this.onStatusChange = options.onStatusChange || (() => {});
+    }
+
+    /**
+     * Check if browser supports audio capture
+     */
+    static isSupported() {
+        return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
+    }
+
+    /**
+     * Get detailed support info for debugging
+     */
+    static getSupportInfo() {
+        const isSecureContext = window.isSecureContext;
+        const hasMediaDevices = !!navigator.mediaDevices;
+        const hasGetUserMedia = !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
+
+        return {
+            isSecureContext,
+            hasMediaDevices,
+            hasGetUserMedia,
+            isSupported: hasGetUserMedia,
+            reason: !isSecureContext
+                ? 'Not a secure context (requires HTTPS or localhost)'
+                : !hasMediaDevices
+                    ? 'navigator.mediaDevices not available'
+                    : !hasGetUserMedia
+                        ? 'getUserMedia not available'
+                        : 'Supported'
+        };
+    }
+
+    /**
+     * Request microphone permission and get stream
+     */
+    async requestMicrophoneAccess() {
+        if (!AudioCaptureManager.isSupported()) {
+            throw new Error('Audio capture not supported in this browser');
+        }
+
+        try {
+            this.stream = await navigator.mediaDevices.getUserMedia({
+                audio: {
+                    channelCount: 1,
+                    sampleRate: this.sampleRate,
+                    echoCancellation: true,
+                    noiseSuppression: true,
+                }
+            });
+            console.log('[AudioCapture] Microphone access granted');
+            return true;
+        } catch (error) {
+            if (error.name === 'NotAllowedError') {
+                throw new Error('Microphone permission denied');
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Start recording audio (call on button press)
+     */
+    async startRecording() {
+        if (this.isRecording) return;
+
+        // Get mic access if not already done
+        if (!this.stream) {
+            await this.requestMicrophoneAccess();
+        }
+
+        // Create audio context
+        this.audioContext = new (window.AudioContext || window.webkitAudioContext)({
+            sampleRate: this.sampleRate
+        });
+
+        // Create source from stream
+        this.source = this.audioContext.createMediaStreamSource(this.stream);
+
+        // Create script processor for audio data capture
+        const bufferSize = 4096;
+        this.processor = this.audioContext.createScriptProcessor(bufferSize, 1, 1);
+
+        // Connect nodes
+        this.source.connect(this.processor);
+        this.processor.connect(this.audioContext.destination);
+
+        // Clear buffer
+        this.audioBuffer = [];
+
+        // Process audio
+        this.processor.onaudioprocess = (event) => {
+            if (!this.isRecording) return;
+            const inputData = event.inputBuffer.getChannelData(0);
+            this.audioBuffer.push(new Float32Array(inputData));
+        };
+
+        this.isRecording = true;
+        this.onStatusChange('recording');
+        console.log('[AudioCapture] Recording started');
+    }
+
+    /**
+     * Stop recording and return captured audio (call on button release)
+     */
+    stopRecording() {
+        if (!this.isRecording) return null;
+
+        this.isRecording = false;
+
+        // Disconnect processor
+        if (this.processor) {
+            this.processor.disconnect();
+            this.processor = null;
+        }
+
+        if (this.source) {
+            this.source.disconnect();
+            this.source = null;
+        }
+
+        if (this.audioContext) {
+            this.audioContext.close();
+            this.audioContext = null;
+        }
+
+        // Concatenate all captured audio
+        const audioData = this.concatenateBuffers(this.audioBuffer);
+        const duration = audioData.length / this.sampleRate;
+        console.log(`[AudioCapture] Recording stopped: ${duration.toFixed(2)}s, ${audioData.length} samples`);
+
+        this.audioBuffer = [];
+        this.onStatusChange('idle');
+
+        // Return captured audio if long enough (at least 0.5s)
+        if (duration >= 0.5) {
+            this.onAudioCaptured(audioData, this.sampleRate);
+            return audioData;
+        } else {
+            console.log('[AudioCapture] Recording too short, discarding');
+            return null;
+        }
+    }
+
+    /**
+     * Concatenate Float32Array buffers into single array
+     */
+    concatenateBuffers(buffers) {
+        const totalLength = buffers.reduce((sum, buf) => sum + buf.length, 0);
+        const result = new Float32Array(totalLength);
+        let offset = 0;
+        for (const buffer of buffers) {
+            result.set(buffer, offset);
+            offset += buffer.length;
+        }
+        return result;
+    }
+
+    /**
+     * Cleanup resources
+     */
+    cleanup() {
+        this.stopRecording();
+
+        if (this.stream) {
+            this.stream.getTracks().forEach(track => track.stop());
+            this.stream = null;
+        }
+    }
+
+    /**
+     * Check if currently recording
+     */
+    getIsRecording() {
+        return this.isRecording;
+    }
+}

--- a/frontend/static/js/live-ask/intent-detector.js
+++ b/frontend/static/js/live-ask/intent-detector.js
@@ -1,0 +1,192 @@
+/**
+ * IntentDetector - Detects if transcribed text is a question for ActionSync
+ *
+ * Uses wake word detection and question pattern matching.
+ * No external API calls - all detection happens locally.
+ */
+
+export class IntentDetector {
+    constructor(options = {}) {
+        // Wake words (case-insensitive)
+        this.wakeWords = options.wakeWords || [
+            'action sync',
+            'actionsync',
+            'hey action sync',
+            'hey actionsync',
+            'ok action sync',
+            'ok actionsync',
+        ];
+
+        // Question starters
+        this.questionStarters = [
+            'what', 'how', 'why', 'when', 'where', 'who', 'which',
+            'is there', 'are there', 'is it', 'are we', 'do we', 'does',
+            'can you', 'could you', 'would you', 'will you',
+            'can we', 'could we', 'should we',
+            'tell me', 'show me', 'find', 'search', 'look up',
+            'explain', 'describe', 'list',
+        ];
+
+        // Confidence thresholds
+        this.wakeWordConfidence = 0.9;
+        this.questionPatternConfidence = 0.7;
+        this.minConfidenceThreshold = options.minConfidenceThreshold || 0.6;
+    }
+
+    /**
+     * Detect if text is a question for ActionSync
+     * @param {string} text - Transcribed text
+     * @returns {{ isQuestion: boolean, confidence: number, cleanedText: string }}
+     */
+    detect(text) {
+        if (!text || typeof text !== 'string') {
+            return { isQuestion: false, confidence: 0, cleanedText: '' };
+        }
+
+        const lowerText = text.toLowerCase().trim();
+
+        // REQUIRE wake word - only process if "ActionSync" is mentioned
+        const wakeWordResult = this.checkWakeWord(lowerText);
+        if (wakeWordResult.found) {
+            const textAfter = wakeWordResult.textAfterWakeWord;
+
+            // Need some actual content after the wake word
+            if (textAfter && textAfter.length > 3) {
+                return {
+                    isQuestion: true,
+                    confidence: this.wakeWordConfidence,
+                    cleanedText: textAfter,
+                    reason: 'wake_word'
+                };
+            } else {
+                // Wake word detected but no question yet - wait for more
+                return {
+                    isQuestion: false,
+                    confidence: 0.3,
+                    cleanedText: text.trim(),
+                    reason: 'wake_word_only'
+                };
+            }
+        }
+
+        // No wake word - don't process (just log the transcription)
+        return {
+            isQuestion: false,
+            confidence: 0,
+            cleanedText: text.trim(),
+            reason: 'no_wake_word'
+        };
+    }
+
+    /**
+     * Check if text contains a wake word
+     */
+    checkWakeWord(text) {
+        for (const wakeWord of this.wakeWords) {
+            const index = text.indexOf(wakeWord);
+            if (index !== -1) {
+                // Extract text after wake word
+                let textAfter = text.slice(index + wakeWord.length).trim();
+
+                // Remove common punctuation/filler after wake word
+                textAfter = textAfter.replace(/^[,.\s]+/, '').trim();
+
+                return {
+                    found: true,
+                    wakeWord: wakeWord,
+                    textAfterWakeWord: textAfter || text // fallback to full text if nothing after
+                };
+            }
+        }
+
+        return { found: false };
+    }
+
+    /**
+     * Check if text matches question patterns
+     */
+    checkQuestionPattern(text) {
+        let confidence = 0;
+        let reasons = [];
+
+        // Check if ends with question mark
+        if (text.endsWith('?')) {
+            confidence += 0.4;
+            reasons.push('ends_with_question_mark');
+        }
+
+        // Check if starts with question word
+        for (const starter of this.questionStarters) {
+            if (text.startsWith(starter + ' ') || text.startsWith(starter + ',')) {
+                confidence += 0.4;
+                reasons.push(`starts_with_${starter}`);
+                break;
+            }
+        }
+
+        // Check for interrogative structure
+        if (this.hasInterrogativeStructure(text)) {
+            confidence += 0.2;
+            reasons.push('interrogative_structure');
+        }
+
+        // Cap confidence at 0.85 for pattern matching (wake word is higher)
+        confidence = Math.min(confidence, 0.85);
+
+        return {
+            isQuestion: confidence >= this.minConfidenceThreshold,
+            confidence: confidence,
+            reasons: reasons
+        };
+    }
+
+    /**
+     * Check for interrogative sentence structure
+     */
+    hasInterrogativeStructure(text) {
+        // Inverted verb-subject patterns
+        const invertedPatterns = [
+            /^(is|are|was|were|do|does|did|can|could|will|would|should|have|has|had)\s+\w+/i,
+        ];
+
+        for (const pattern of invertedPatterns) {
+            if (pattern.test(text)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Add custom wake word
+     */
+    addWakeWord(word) {
+        const normalized = word.toLowerCase().trim();
+        if (!this.wakeWords.includes(normalized)) {
+            this.wakeWords.push(normalized);
+        }
+    }
+
+    /**
+     * Remove wake word
+     */
+    removeWakeWord(word) {
+        const normalized = word.toLowerCase().trim();
+        const index = this.wakeWords.indexOf(normalized);
+        if (index !== -1) {
+            this.wakeWords.splice(index, 1);
+        }
+    }
+
+    /**
+     * Get current configuration
+     */
+    getConfig() {
+        return {
+            wakeWords: [...this.wakeWords],
+            questionStarters: [...this.questionStarters],
+            minConfidenceThreshold: this.minConfidenceThreshold
+        };
+    }
+}

--- a/frontend/static/js/live-ask/live-ask-controller.js
+++ b/frontend/static/js/live-ask/live-ask-controller.js
@@ -1,0 +1,212 @@
+/**
+ * LiveAskController - Push-to-Talk Voice Questions
+ *
+ * Hold mic button to record, release to transcribe and ask.
+ */
+
+import { AudioCaptureManager } from '/static/js/live-ask/audio-capture.js';
+import { WhisperTranscriber } from '/static/js/live-ask/whisper-transcriber.js';
+
+export class LiveAskController {
+    constructor(options = {}) {
+        // Components
+        this.audioCapture = new AudioCaptureManager({
+            onAudioCaptured: (audio, sampleRate) => this.handleAudioCaptured(audio, sampleRate),
+            onError: (err) => this.handleError(err),
+            onStatusChange: (status) => this.updateStatus(status),
+        });
+
+        this.transcriber = new WhisperTranscriber({
+            onLoadProgress: (progress) => this.handleModelProgress(progress),
+            onError: (err) => this.handleError(err),
+        });
+
+        // State
+        this.ready = false;
+        this.status = 'idle'; // 'idle' | 'loading' | 'recording' | 'transcribing' | 'processing'
+        this.modelProgress = 0;
+
+        // Callbacks
+        this.onStatusChange = options.onStatusChange || (() => {});
+        this.onModelProgress = options.onModelProgress || (() => {});
+        this.onTranscription = options.onTranscription || (() => {});
+        this.onError = options.onError || console.error;
+
+        // Question handler (will be set to call askQuestion)
+        this.askQuestionHandler = options.askQuestionHandler || null;
+    }
+
+    /**
+     * Check if Live Ask is supported in this browser
+     */
+    static isSupported() {
+        return AudioCaptureManager.isSupported();
+    }
+
+    /**
+     * Get detailed support info
+     */
+    static getSupportInfo() {
+        return AudioCaptureManager.getSupportInfo();
+    }
+
+    /**
+     * Initialize - load Whisper model
+     */
+    async initialize() {
+        if (this.ready) return;
+
+        try {
+            this.updateStatus('loading');
+
+            // Load Whisper model (can take time on first load)
+            if (!this.transcriber.isLoaded) {
+                console.log('[LiveAsk] Loading Whisper model...');
+                await this.transcriber.loadModel();
+                console.log('[LiveAsk] Whisper model loaded');
+            }
+
+            // Request mic permission early
+            await this.audioCapture.requestMicrophoneAccess();
+
+            this.ready = true;
+            this.updateStatus('idle');
+
+        } catch (error) {
+            console.error('[LiveAsk] Initialize error:', error);
+            this.updateStatus('idle');
+            this.handleError(error);
+            throw error;
+        }
+    }
+
+    /**
+     * Start recording (call on button press)
+     */
+    async startRecording() {
+        if (!this.ready) {
+            await this.initialize();
+        }
+
+        try {
+            await this.audioCapture.startRecording();
+            this.updateStatus('recording');
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    /**
+     * Stop recording and process (call on button release)
+     */
+    async stopRecording() {
+        this.audioCapture.stopRecording();
+        // Audio will be processed via onAudioCaptured callback
+    }
+
+    /**
+     * Handle captured audio
+     */
+    async handleAudioCaptured(audioData, sampleRate) {
+        console.log(`[LiveAsk] Audio captured: ${audioData.length} samples`);
+
+        try {
+            this.updateStatus('transcribing');
+
+            // Transcribe the audio
+            const text = await this.transcriber.transcribe(audioData);
+            console.log('[LiveAsk] Transcription:', text);
+
+            if (!text || text.trim().length < 3) {
+                console.log('[LiveAsk] Transcription too short, ignoring');
+                this.updateStatus('idle');
+                return;
+            }
+
+            this.onTranscription(text.trim());
+
+            // Process as question (no intent detection needed - user intentionally recorded)
+            if (this.askQuestionHandler) {
+                this.updateStatus('processing');
+                await this.askQuestionHandler(text.trim());
+            }
+
+            this.updateStatus('idle');
+
+        } catch (error) {
+            this.handleError(error);
+            this.updateStatus('idle');
+        }
+    }
+
+    /**
+     * Handle model loading progress
+     */
+    handleModelProgress(progress) {
+        this.modelProgress = progress.progress;
+        this.onModelProgress(progress);
+    }
+
+    /**
+     * Update status and notify
+     */
+    updateStatus(status) {
+        this.status = status;
+        this.onStatusChange(status);
+    }
+
+    /**
+     * Handle errors
+     */
+    handleError(error) {
+        console.error('[LiveAsk] Error:', error);
+        this.onError(error);
+    }
+
+    /**
+     * Set the question handler
+     */
+    setAskQuestionHandler(handler) {
+        this.askQuestionHandler = handler;
+    }
+
+    /**
+     * Get current state
+     */
+    getState() {
+        return {
+            ready: this.ready,
+            status: this.status,
+            modelLoaded: this.transcriber.isLoaded,
+            modelLoading: this.transcriber.isLoading,
+            modelProgress: this.modelProgress,
+            isRecording: this.audioCapture.getIsRecording(),
+        };
+    }
+
+    /**
+     * Cleanup resources
+     */
+    destroy() {
+        this.audioCapture.cleanup();
+        this.transcriber.unloadModel();
+        this.ready = false;
+    }
+}
+
+// Export singleton instance
+let instance = null;
+
+export function getLiveAskController(options) {
+    if (!instance) {
+        instance = new LiveAskController(options);
+    }
+    return instance;
+}
+
+export function destroyLiveAskController() {
+    if (instance) {
+        instance.destroy();
+        instance = null;
+    }
+}

--- a/frontend/static/js/live-ask/whisper-transcriber.js
+++ b/frontend/static/js/live-ask/whisper-transcriber.js
@@ -1,0 +1,200 @@
+/**
+ * WhisperTranscriber - Local speech-to-text using Whisper via transformers.js
+ *
+ * Uses Hugging Face's transformers.js to run Whisper entirely in the browser.
+ * Model is downloaded once and cached in IndexedDB.
+ */
+
+// We'll dynamically import transformers.js to avoid blocking page load
+let pipeline = null;
+
+export class WhisperTranscriber {
+    constructor(options = {}) {
+        // Model configuration - Xenova models are optimized for browser use
+        this.modelId = options.modelId || 'Xenova/whisper-tiny.en';
+        this.device = options.device || 'webgpu'; // 'webgpu' or 'wasm'
+
+        // State
+        this.transcriber = null;
+        this.isLoading = false;
+        this.isLoaded = false;
+
+        // Callbacks
+        this.onLoadProgress = options.onLoadProgress || (() => {});
+        this.onError = options.onError || console.error;
+    }
+
+    /**
+     * Check if WebGPU is available for faster inference
+     */
+    static async isWebGPUAvailable() {
+        if (!navigator.gpu) return false;
+        try {
+            const adapter = await navigator.gpu.requestAdapter();
+            return !!adapter;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Load the Whisper model
+     */
+    async loadModel() {
+        if (this.isLoaded) return;
+        if (this.isLoading) {
+            // Wait for existing load to complete
+            while (this.isLoading) {
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+            return;
+        }
+
+        this.isLoading = true;
+
+        try {
+            // Dynamically import transformers.js
+            if (!pipeline) {
+                console.log('Importing transformers.js...');
+                const transformers = await import(
+                    'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.0'
+                );
+                pipeline = transformers.pipeline;
+                console.log('transformers.js imported successfully');
+            }
+
+            // Progress callback for model loading
+            const progressCallback = (progress) => {
+                console.log('Model load progress:', progress);
+                if (progress.status === 'progress') {
+                    const percent = Math.round((progress.loaded / progress.total) * 100);
+                    this.onLoadProgress({
+                        status: 'downloading',
+                        progress: percent,
+                        file: progress.file
+                    });
+                } else if (progress.status === 'ready') {
+                    this.onLoadProgress({
+                        status: 'ready',
+                        progress: 100
+                    });
+                }
+            };
+
+            // Try WebGPU first, fall back to WASM with different dtypes
+            const backends = [];
+            const useWebGPU = await WhisperTranscriber.isWebGPUAvailable();
+            if (useWebGPU) {
+                backends.push({ device: 'webgpu', dtype: 'fp32' });
+            }
+            // WASM fallback - try without dtype first (let transformers.js choose)
+            backends.push({ device: 'wasm', dtype: null });
+            backends.push({ device: 'wasm', dtype: 'fp32' });
+
+            let lastError = null;
+            for (const backend of backends) {
+                try {
+                    console.log(`Trying ${backend.device} backend with dtype=${backend.dtype || 'auto'}...`);
+
+                    const pipelineOptions = {
+                        device: backend.device,
+                        progress_callback: progressCallback
+                    };
+
+                    // Only set dtype if explicitly specified
+                    if (backend.dtype) {
+                        pipelineOptions.dtype = backend.dtype;
+                    }
+
+                    this.transcriber = await pipeline(
+                        'automatic-speech-recognition',
+                        this.modelId,
+                        pipelineOptions
+                    );
+
+                    this.isLoaded = true;
+                    console.log(`Whisper model loaded successfully with ${backend.device} backend`);
+                    return; // Success, exit
+
+                } catch (backendError) {
+                    // Convert numeric ONNX errors to proper Error objects
+                    const errorMessage = typeof backendError === 'number'
+                        ? `ONNX runtime error code: ${backendError}`
+                        : (backendError?.message || String(backendError));
+
+                    console.warn(`Failed to load with ${backend.device}: ${errorMessage}`);
+                    lastError = new Error(`${backend.device} backend failed: ${errorMessage}`);
+                }
+            }
+
+            // All backends failed
+            throw lastError || new Error('Failed to load Whisper model with any backend');
+
+        } catch (error) {
+            // Ensure we always have a proper Error object
+            const normalizedError = error instanceof Error
+                ? error
+                : new Error(typeof error === 'number'
+                    ? `ONNX runtime error code: ${error}`
+                    : String(error));
+
+            console.error('Whisper model load error:', normalizedError);
+            this.onError(normalizedError);
+            throw normalizedError;
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    /**
+     * Transcribe audio data
+     * @param {Float32Array} audioData - Audio samples at 16kHz
+     * @returns {Promise<string>} - Transcribed text
+     */
+    async transcribe(audioData) {
+        console.log(`[Whisper] transcribe called, isLoaded: ${this.isLoaded}, audioData length: ${audioData?.length}`);
+
+        if (!this.isLoaded) {
+            console.log('[Whisper] Model not loaded, loading now...');
+            await this.loadModel();
+        }
+
+        try {
+            console.log('[Whisper] Calling transcriber pipeline...');
+            const result = await this.transcriber(audioData, {
+                chunk_length_s: 30,
+                stride_length_s: 5,
+                return_timestamps: false,
+            });
+
+            console.log('[Whisper] Transcription complete:', result);
+            return result.text.trim();
+
+        } catch (error) {
+            this.onError(error);
+            throw error;
+        }
+    }
+
+    /**
+     * Unload the model to free memory
+     */
+    async unloadModel() {
+        if (this.transcriber) {
+            // transformers.js doesn't have explicit unload, but we can null the reference
+            this.transcriber = null;
+            this.isLoaded = false;
+        }
+    }
+
+    /**
+     * Get model loading status
+     */
+    getStatus() {
+        return {
+            isLoading: this.isLoading,
+            isLoaded: this.isLoaded,
+            modelId: this.modelId
+        };
+    }
+}

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ActionSync - Meeting to Jira</title>
-    <link rel="stylesheet" href="/static/css/styles.css?v=29">
+    <link rel="stylesheet" href="/static/css/styles.css?v=50">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📋</text></svg>">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
@@ -12,6 +12,6 @@
 <body>
     <div id="app"></div>
     <div class="toast-container" id="toast-container"></div>
-    <script src="/static/js/app.js?v=29"></script>
+    <script src="/static/js/app.js?v=49"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add push-to-talk voice questions using local Whisper transcription (privacy-preserving, no API costs)
- Implement session management for multi-turn conversations (follow-ups continue the same Claude session)
- Display conversation history in chat-like UI
- Support follow-up questions via voice or text

## What's included

**Frontend:**
- New `live-ask` module with audio capture, Whisper transcriber, and controller
- Conversation view with user/assistant message styling  
- Mic button in Ask mode input area and follow-up input
- Model cached in IndexedDB after first load (~39MB)

**Backend:**
- `SessionManager` to maintain Claude SDK sessions between questions
- Session-aware `ask_jira_question` with `session_id` parameter
- 30-minute session timeout with automatic cleanup

## How it works

1. Click mic button to start recording
2. Click again to stop - audio transcribed locally via Whisper
3. Question sent to Claude with session context
4. Answer displayed in conversation view
5. Follow-up questions continue the same session

## Test plan

- [ ] Enable Ask mode, click mic, speak a question, click to stop
- [ ] Verify transcription appears and answer is displayed
- [ ] Ask a follow-up question (voice or text) - should have context
- [ ] Click "New" to start fresh conversation
- [ ] Verify conversation history displays correctly

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)